### PR TITLE
fix the [clib install littlstar/soil command failed] issue

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -5,7 +5,6 @@
   "description": "Simple OpenGL Image Library",
   "keywords": ["soil", "opengl", "gl", "image"],
   "configure": "configure",
-  "makefile": "Makefile",
   "src": [
    "include/SOIL/SOIL.h",
    "include/SOIL/image_dxt.h",

--- a/clib.json
+++ b/clib.json
@@ -4,7 +4,6 @@
   "repo": "littlstar/soil",
   "description": "Simple OpenGL Image Library",
   "keywords": ["soil", "opengl", "gl", "image"],
-  "configure": "configure",
   "src": [
    "include/SOIL/SOIL.h",
    "include/SOIL/image_dxt.h",

--- a/clib.json
+++ b/clib.json
@@ -19,5 +19,7 @@
 
    "configure",
    "Makefile.in"
-  ]
+  ],
+  "install": "./configure && make && make install",
+  "uninstall": "make uninstall"
 }


### PR DESCRIPTION
Hoping someone can find this PR,
seems like clib changed their spec of clib.json file.
I can run [clib install sunpaq/soil] without any issue with this fix.